### PR TITLE
Implement learning improve card selection

### DIFF
--- a/src/helpers/learningSessionManager.ts
+++ b/src/helpers/learningSessionManager.ts
@@ -1,14 +1,23 @@
 import { Deck, LearningSession, LearningSessionElement } from "@/types";
 
+/* numberOfRecentCardsToIgnoreWhenSelectingNextCard defines when a card can be used again;
+ * it's an object where the key defines the rating for which this rule applies and the value
+ * says how many other cards need to be used before the card can be used again
+ */
+
 export default class LearningSessionManager {
   decks = [] as Deck[];
-  numberOfRecentCardsToIgnoreWhenSelectingNextCard = -1;
+  numberOfRecentCardsToIgnoreWhenSelectingNextCard: {
+    [rating: number]: number;
+  } = {};
   cardsToSelectFrom = [] as LearningSessionElement[];
   learningSession = {} as LearningSession;
 
   constructor(
     selectedDecks: Deck[],
-    numberOfRecentCardsToIgnoreWhenSelectingNextCard = -1
+    numberOfRecentCardsToIgnoreWhenSelectingNextCard: {
+      [rating: number]: number;
+    } = {}
   ) {
     this.decks = selectedDecks;
     this.numberOfRecentCardsToIgnoreWhenSelectingNextCard = numberOfRecentCardsToIgnoreWhenSelectingNextCard;
@@ -36,18 +45,25 @@ export default class LearningSessionManager {
     const randomCardIndex = this.getRandomCardIndex();
     this.learningSession.elements.push(this.cardsToSelectFrom[randomCardIndex]);
     this.cardsToSelectFrom.splice(randomCardIndex, 1);
-    if (this.numberOfRecentCardsToIgnoreWhenSelectingNextCard >= 0) {
-      const indexOfCardToBeUsedAgainForSelection =
+
+    for (const ruleRating in this
+      .numberOfRecentCardsToIgnoreWhenSelectingNextCard) {
+      const indexOfCardToBePossiblyUsedAgainForSelection =
         this.learningSession.elements.length -
-        (this.numberOfRecentCardsToIgnoreWhenSelectingNextCard + 1);
-      if (indexOfCardToBeUsedAgainForSelection >= 0) {
+        (this.numberOfRecentCardsToIgnoreWhenSelectingNextCard[
+          Number(ruleRating)
+        ] +
+          1);
+      if (indexOfCardToBePossiblyUsedAgainForSelection >= 0) {
         const cardToBeUsedAgainForSelection = this.learningSession.elements[
-          indexOfCardToBeUsedAgainForSelection
+          indexOfCardToBePossiblyUsedAgainForSelection
         ];
-        this.cardsToSelectFrom.push({
-          deckId: cardToBeUsedAgainForSelection.deckId,
-          cardId: cardToBeUsedAgainForSelection.cardId,
-        });
+        if (cardToBeUsedAgainForSelection.rating?.r === Number(ruleRating)) {
+          this.cardsToSelectFrom.push({
+            deckId: cardToBeUsedAgainForSelection.deckId,
+            cardId: cardToBeUsedAgainForSelection.cardId,
+          });
+        }
       }
     }
     return true;

--- a/src/helpers/learningSessionManager.ts
+++ b/src/helpers/learningSessionManager.ts
@@ -1,9 +1,32 @@
-import { Deck, LearningSession, LearningSessionElement } from "@/types";
+import { Card, Deck, LearningSession, LearningSessionElement } from "@/types";
 
 /* numberOfRecentCardsToIgnoreWhenSelectingNextCard defines when a card can be used again;
  * it's an object where the key defines the rating for which this rule applies and the value
  * says how many other cards need to be used before the card can be used again
  */
+
+const today = new Date().getTime();
+function getCardWeigthBasedOnRecentRatings(card: Card): number {
+  const defaultWeightForUnusedCards = 80;
+  let weight;
+  if (card.r === undefined || card.r.length === 0) {
+    weight = defaultWeightForUnusedCards;
+  } else {
+    const mostRecentCardRating = card.r.reduce(
+      (mostRecentRatingObj, curRatingObj) =>
+        curRatingObj.t > mostRecentRatingObj.t
+          ? curRatingObj
+          : mostRecentRatingObj
+    );
+    // downgrade rating (0-100) by one for each day
+    const daysSinceLastRating =
+      (today - mostRecentCardRating.t) / (1000 * 60 * 60 * 24);
+    const virtualRating = mostRecentCardRating.r - daysSinceLastRating;
+    // map virtual rating to weight
+    weight = Math.max(0, 100 - virtualRating) || 1;
+  }
+  return weight;
+}
 
 export default class LearningSessionManager {
   decks = [] as Deck[];
@@ -31,6 +54,7 @@ export default class LearningSessionManager {
           showAnswer: false,
           rating: undefined,
           card: undefined,
+          weight: getCardWeigthBasedOnRecentRatings(card),
         });
       });
     });
@@ -70,6 +94,19 @@ export default class LearningSessionManager {
   }
 
   getRandomCardIndex(): number {
+    const sumWeights = this.cardsToSelectFrom.reduce(
+      (sum, card) => sum + (card.weight || 0),
+      0
+    );
+    const randomNumberInWeightSumRange = Math.random() * sumWeights;
+    let curWeightSum = 0;
+    for (let index = 0; index < this.cardsToSelectFrom.length; index++) {
+      curWeightSum += this.cardsToSelectFrom[index].weight || 0;
+      if (curWeightSum > randomNumberInWeightSumRange) {
+        return index;
+      }
+    }
+    // if random card selection based on some weighted distribution didn't work, assume even distribution
     return Math.floor(Math.random() * this.cardsToSelectFrom.length);
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -59,6 +59,7 @@ export interface LearningSessionElement {
   showAnswer?: boolean;
   rating?: CardRating;
   card?: Card;
+  weight?: number;
 }
 
 export interface CustomDialogOptions {


### PR DESCRIPTION
@FischerRene I implemented card selection based on a weight distribution that defines the probability for the card of getting selected. Additionally I switched our previous constant number of how many recent cards should be ignored to an object that defines this number based on the rating, so that e.g. a card with rating 100 can not be repeated in the same session, a card with rating 50 after 10 cards and a card with rating 0 after 2.

We are currently not using the latter one, but it might be useful in the future and as Mister Gömert always says, it's not like it eat's bread.

Feel free to update my current implementation for defining the weight based on the most recent rating, especially downgrading to our virtual rating and mapping this to a weight.



There might be problems with mapping the rating from 1-n to 0-100 if it doesn't work so nice like with 1-5. I mean it could be 1-4 and thus 0, 33.3, 66.6 and 100 which would not work at some points in our current implementation I believe. We should keep that in mind that switching from 5 stars to another number could cause problems and our current implementation is not generic at this point.

Also we are assuming currently that the rating 1-5 can be ordered and the difference between adjacent ratings is the same, meaning that difference between 1 and 2 is same as difference between 4 and 5. That may depend on how a user interprets the scale.