### PR TITLE
allow decks to be updated

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -1,4 +1,5 @@
 const fs = require("fs");
+const { v4: uuidv4 } = require('uuid');
 const readline = require('readline').createInterface({
     input: process.stdin,
     output: process.stdout
@@ -72,6 +73,7 @@ async function cliEditFile (filename) {
     if (!curFilename.endsWith(".json")) curFilename += ".json";
     curFileContent = await readJSONFromFile(curFilename);
     console.log(`now editing ${curFilename}`);
+    addUUIDToFileIfItExistsNotYet();
     while (true) {
         const cmd = await readCommand(`Commands: new deck <name>, list decks, edit deck <name>, delete deck <name>, show meta, meta <attr> <value>, whereami, back`);
         if (cmd.startsWith("new deck ")) {
@@ -120,6 +122,12 @@ async function cliEditFile (filename) {
         } else {
             console.log("Your command was not understood...");
         }
+    }
+}
+
+function addUUIDToFileIfItExistsNotYet () {
+    if (!("uuid" in curFileContent.meta)) {
+        curFileContent.meta.uuid = uuidv4();
     }
 }
 

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "cli",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "uuid": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.2.0.tgz",
+      "integrity": "sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q=="
+    }
+  }
+}

--- a/cli/package.json
+++ b/cli/package.json
@@ -9,5 +9,8 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Niko Lockenvitz",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "uuid": "^8.2.0"
+  }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -352,13 +352,15 @@ We also want to have a look into tour testing as an extension to our current exp
 ### Some ideas
 Ideas we want to implement in the future, but did not have enough time to implement or work out completely.
 
-- update decks and keep learning progress
+- add security measures when updating decks (e.g. signatures, see [#16](https://github.com/fancy-flashcard/ffc/pull/16))
 - extend format and displaying in app to show not only simple text
   - Markdown support
   - formulas similar to LaTeX
   - image support
   - suggested answers to choose from (quiz-like, see below)
-- deck library, recommended decks
+- extend deck library / recommended decks / third-party-decks
+  - instructions how to make it to the third party deck list
+  - maybe some UI based deck creation
 - optimize random card selection algorithm + make it customizable in app settings
 - import decks from a website even if no CORS headers are sent, see [no-cors.md](no-cors.md)
 - analytics for insights into individial learning progress

--- a/docs/README.md
+++ b/docs/README.md
@@ -182,6 +182,8 @@ Our first proposal is as follows:
 {
     "meta": {
         "author": "Name of the Author",
+        "uuid": "Optional UUID to allow updates (especially for local files)",
+        "url": "This keyword is reserved for internal use and will be overridden. Do not use it.",
         "...": "..."
     },
     "decks": {
@@ -190,6 +192,7 @@ Our first proposal is as follows:
                 "deck_name": "Full Name of the Deck",
                 "description": "Description",
                 "next_card_id": 3,
+                "short_name": "This keyword is reserved for internal use and will be overridden. Do not use it.",
                 "...": "..."
             },
             "cards": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc",
-  "version": "0.1.0",
+  "version": "1.1.0",
   "author": "Niko Lockenvitz & Rene-Pascal Fischer",
   "license": "MIT",
   "private": true,

--- a/src/components/addnewdeck/ImportDeckFromURL.vue
+++ b/src/components/addnewdeck/ImportDeckFromURL.vue
@@ -26,6 +26,8 @@
 import Vue from "vue";
 import Component from "vue-class-component";
 
+import { Event } from "../../types";
+
 @Component
 export default class ImportDeckFromURL extends Vue {
   chosenURL = "";
@@ -39,12 +41,12 @@ export default class ImportDeckFromURL extends Vue {
     try {
       const response = await fetch(this.chosenURL);
       const fileContent = await response.json();
-      this.$eventHub.$emit("addDecksFromJSON", fileContent);
+      this.$eventHub.$emit(Event.ADD_DECKS_FROM_JSON, fileContent, this.chosenURL);
     } catch (error) {
       // console.log(error);
       // TODO: cors?!
       this.$eventHub.$emit(
-        "snackbarEvent",
+        Event.SNACKBAR_EVENT,
         "An error occurred while loading the file"
       );
     }

--- a/src/components/thirdparty/ThirdPartyDeckSelection.vue
+++ b/src/components/thirdparty/ThirdPartyDeckSelection.vue
@@ -36,7 +36,7 @@ import Vue from "vue";
 import Component from "vue-class-component";
 import thirdPartyList from "../../../third-party-decks.json";
 
-import { ThirdPartyDeck } from "../../types";
+import { Event, ThirdPartyDeck } from "../../types";
 
 @Component
 export default class ThirdPartyDeckSelection extends Vue {
@@ -75,17 +75,17 @@ export default class ThirdPartyDeckSelection extends Vue {
       ]
     };
 
-    this.$eventHub.$emit("showCustomDialog", options);
+    this.$eventHub.$emit(Event.SHOW_CUSTOM_DIALOG, options);
   }
 
   async onDownload(url: string) {
     try {
       const response = await fetch(url);
       const fileContent = await response.json();
-      this.$eventHub.$emit("addDecksFromJSON", fileContent);
+      this.$eventHub.$emit(Event.ADD_DECKS_FROM_JSON, fileContent, url);
     } catch (error) {
       this.$eventHub.$emit(
-        "snackbarEvent",
+        Event.SNACKBAR_EVENT,
         "An error occurred while loading the third party deck"
       );
     }

--- a/src/helpers/addDecksHelper.ts
+++ b/src/helpers/addDecksHelper.ts
@@ -1,31 +1,43 @@
-import { FFCFile, Deck, CustomDialogOptions } from '@/types';
-import router from '@/router';
-import { showSnackbar } from './snackbarHelper';
+import { FFCFile, Deck, Card, CustomDialogOptions } from "@/types";
+import router from "@/router";
+import { showSnackbar } from "./snackbarHelper";
 
 interface Context {
-  decks: Deck[],
-  showCustomDialog: Function,
-  $router: typeof router,
+  decks: Deck[];
+  showCustomDialog: Function;
+  $router: typeof router;
 }
 
-export function addDecksFromFile(context: Context, fileContent: string) {
+export function addDecksFromFile(
+  context: Context,
+  fileContent: string,
+  url?: string
+) {
   try {
-    addDecksFromJSON(context, JSON.parse(fileContent));
+    addDecksFromJSON(context, JSON.parse(fileContent), url);
   } catch (e) {
     showSnackbar(context, e);
   }
 }
 
 interface addedDeckAndCards {
-  name: string,
-  numberOfCards: number,
+  name: string;
+  numberOfCards: number;
+  addedCards?: number;
+  updatedCards?: number;
+  deletedCards?: number;
 }
 
-export function addDecksFromJSON(context: Context, fileContent: FFCFile) {
+export function addDecksFromJSON(
+  context: Context,
+  fileContent: FFCFile,
+  url?: string
+) {
   const addedDecksAndCards = [] as addedDeckAndCards[];
   try {
+    let updatedInsteadOfAddedFile = false;
     for (const deckShortName in fileContent.decks) {
-      const cards = [];
+      const cards: Card[] = [];
       for (const cardId in fileContent.decks[deckShortName].cards) {
         cards.push({
           id: Number(cardId),
@@ -35,6 +47,25 @@ export function addDecksFromJSON(context: Context, fileContent: FFCFile) {
         });
       }
 
+      // check if deck exists already
+      const updated = updateDeckIfItExistsAndReturnStatusAndNumberOfCards(
+        context.decks,
+        deckShortName,
+        fileContent,
+        url
+      );
+      if (updated.status) {
+        updatedInsteadOfAddedFile = true;
+        addedDecksAndCards.push({
+          name: updated.deckName || "",
+          numberOfCards: cards.length,
+          addedCards: updated.addedCards,
+          updatedCards: updated.updatedCards,
+          deletedCards: updated.deletedCards,
+        });
+        continue;
+      }
+
       const name =
         fileContent.decks[deckShortName].meta.deck_name || deckShortName;
       context.decks.push({
@@ -42,7 +73,10 @@ export function addDecksFromJSON(context: Context, fileContent: FFCFile) {
         selected: false,
         name,
         meta: {
-          file: fileContent.meta,
+          file: {
+            ...fileContent.meta,
+            url,
+          },
           deck: {
             ...fileContent.decks[deckShortName].meta,
             short_name: deckShortName,
@@ -53,13 +87,103 @@ export function addDecksFromJSON(context: Context, fileContent: FFCFile) {
       addedDecksAndCards.push({ name, numberOfCards: cards.length });
     }
 
-    showAddedDecksConfirmation(context, addedDecksAndCards);
+    showAddedDecksConfirmation(
+      context,
+      addedDecksAndCards,
+      updatedInsteadOfAddedFile
+    );
   } catch (e) {
     showSnackbar(context, e);
   }
 }
 
-function showAddedDecksConfirmation(context: Context, addedDeckAndCards: addedDeckAndCards[]) {
+function updateDeckIfItExistsAndReturnStatusAndNumberOfCards(
+  decks: Deck[],
+  deckShortName: string,
+  fileContent: FFCFile,
+  url?: string
+): {
+  status: boolean;
+  deckName?: string;
+  addedCards?: number;
+  updatedCards?: number;
+  deletedCards?: number;
+} {
+  for (const deck of decks) {
+    // if url is known for the local deck, it should only be updated when url matches
+    // this should prevent from maliciously using same uuid to overwrite other decks
+    if (
+      ((deck.meta.file.url && deck.meta.file.url === url) ||
+        (!deck.meta.file.url &&
+          deck.meta.file.uuid &&
+          deck.meta.file.uuid === fileContent.meta.uuid)) &&
+      deck.meta.deck.short_name === deckShortName
+    ) {
+      // should be updated
+      let addedCards = 0,
+        updatedCards = 0,
+        deletedCards = 0;
+
+      deck.name =
+        fileContent.decks[deckShortName].meta.deck_name || deckShortName;
+      deck.meta = {
+        file: {
+          ...fileContent.meta,
+          url: deck.meta.file.url,
+        },
+        deck: {
+          ...fileContent.decks[deckShortName].meta,
+          short_name: deckShortName,
+        },
+      };
+      const alreadyExistingCardIdMap: { [cardId: number]: boolean } = {};
+      for (let i = 0; i < deck.cards.length; i++) {
+        if (deck.cards[i].id in fileContent.decks[deckShortName].cards) {
+          if (
+            deck.cards[i].q !==
+              fileContent.decks[deckShortName].cards[deck.cards[i].id].q ||
+            deck.cards[i].a !==
+              fileContent.decks[deckShortName].cards[deck.cards[i].id].a
+          ) {
+            deck.cards[i].q =
+              fileContent.decks[deckShortName].cards[deck.cards[i].id].q;
+            deck.cards[i].a =
+              fileContent.decks[deckShortName].cards[deck.cards[i].id].a;
+            updatedCards += 1;
+          }
+          alreadyExistingCardIdMap[deck.cards[i].id] = true;
+        } else {
+          deck.cards.splice(i, 1);
+          deletedCards += 1;
+        }
+      }
+      for (const cardId in fileContent.decks[deckShortName].cards) {
+        if (cardId in alreadyExistingCardIdMap) continue;
+        deck.cards.push({
+          id: Number(cardId),
+          q: fileContent.decks[deckShortName].cards[cardId].q,
+          a: fileContent.decks[deckShortName].cards[cardId].a,
+          r: [],
+        });
+        addedCards += 1;
+      }
+      return {
+        status: true,
+        deckName: deck.name,
+        addedCards,
+        updatedCards,
+        deletedCards,
+      };
+    }
+  }
+  return { status: false };
+}
+
+function showAddedDecksConfirmation(
+  context: Context,
+  addedDeckAndCards: addedDeckAndCards[],
+  updatedInsteadOfAddedFile: boolean
+) {
   const numberOfAddedCards = addedDeckAndCards.reduce(
     (total, deck) => total + deck.numberOfCards,
     0
@@ -71,12 +195,15 @@ function showAddedDecksConfirmation(context: Context, addedDeckAndCards: addedDe
   const options = {
     persistent: false,
     title: "Successfully Imported Decks",
-    message: "Following decks have been added:",
+    message: updatedInsteadOfAddedFile
+      ? "Following decks have been updated (you can see the number of cards added, updated and deleted in parentheses):"
+      : "Following decks have been added:",
     tableHead: { name: "Deck", value: "Number of Cards" },
     table: addedDeckAndCards.map((deck) => {
       return {
         name: deck.name,
-        value: String(deck.numberOfCards),
+        value:
+          String(deck.numberOfCards) + showUpdatedInfoForDeckIfUpdated(deck),
       };
     }),
     buttons: [
@@ -94,4 +221,15 @@ function showAddedDecksConfirmation(context: Context, addedDeckAndCards: addedDe
     ],
   } as CustomDialogOptions;
   context.showCustomDialog(options);
+}
+
+function showUpdatedInfoForDeckIfUpdated(deck: addedDeckAndCards): string {
+  if (
+    "addedCards" in deck &&
+    "updatedCards" in deck &&
+    "deletedCards" in deck
+  ) {
+    return ` (${deck.addedCards}/${deck.updatedCards}/${deck.deletedCards})`;
+  }
+  return "";
 }

--- a/src/helpers/eventListener.ts
+++ b/src/helpers/eventListener.ts
@@ -22,8 +22,8 @@ export function registerEventListenerForMainApp(context: any) {
   context.$eventHub.$on(Event.ADD_DECKS_FROM_FILE, (fileContent: string) => {
     addDecksFromFile(context, fileContent);
   });
-  context.$eventHub.$on(Event.ADD_DECKS_FROM_JSON, (fileContent: FFCFile) => {
-    addDecksFromJSON(context, fileContent);
+  context.$eventHub.$on(Event.ADD_DECKS_FROM_JSON, (fileContent: FFCFile, url?: string) => {
+    addDecksFromJSON(context, fileContent, url);
   });
   context.$eventHub.$on(Event.SNACKBAR_EVENT, (message: string) => {
     showSnackbar(context, message);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,7 @@
 export interface FFCFile {
   meta: {
     author: string;
+    uuid?: string;
     [x: string]: any;
   };
   decks: {
@@ -27,9 +28,12 @@ export interface Deck {
   name: string;
   meta: {
     file: {
+      uuid?: string;
+      url?: string;
       [x: string]: any;
     };
     deck: {
+      short_name: string;
       [x: string]: any;
     };
   };


### PR DESCRIPTION
- decks can be updated (learning progress is not lost)
- to detect whether a deck was updated URL or UUID is used
- cli is updated accordingly

Currently I don't allow a deck to be updated from a different URL (even if UUID is the same). I had in mind that someone could just use the UUID of a public deck again to override the cards / delete the learning progress.
In my opinion this should change in the future but I see it as the best option for now.
I would prefer to ask the user before decks are imported / updated -> then we could merge completely to UUIDs and a malicious attack could be noticed before it's to late. From the user perspective this could mean that we just add a third button in the decks-imported-dialog like cancel/revert. We should then need to think about how we do this, either reverting or two loops (prepare update, execute update).

Another option would be to have signatures (i.e. of `hash(meta, decks)` -> either we store the signature in meta and remove it when the signature is checked or we append it at the end of a file)