### PR TITLE
Add versioning to decks

### DIFF
--- a/cli/test.json
+++ b/cli/test.json
@@ -1,7 +1,8 @@
 {
   "meta": {
     "author": "Niko Lockenvitz & Rene-Pascal Fischer",
-    "version": "1.1.1"
+    "version": "1.1.1",
+    "uuid": "6d4b5420-3c3e-42bc-addd-019597fd438b"
   },
   "decks": {
     "d0": {

--- a/cli/test.json
+++ b/cli/test.json
@@ -1,13 +1,14 @@
 {
   "meta": {
-    "author": "Niko Lockenvitz"
+    "author": "Niko Lockenvitz & Rene-Pascal Fischer",
+    "version": "1.1.1"
   },
   "decks": {
     "d0": {
       "meta": {
-        "deck_name": "d0",
+        "deck_name": "A test deck",
         "next_card_id": 2,
-        "description": ""
+        "description": "This is a deck created for testing purposes. It is about \"mathematics\"."
       },
       "cards": {
         "0": {
@@ -22,9 +23,9 @@
     },
     "d1": {
       "meta": {
-        "deck_name": "d1",
+        "deck_name": "Another awesome test deck",
         "next_card_id": 3,
-        "description": ""
+        "description": "This is another deck created for testing purposes. It is about \"time\"."
       },
       "cards": {
         "0": {

--- a/docs/README.md
+++ b/docs/README.md
@@ -369,6 +369,9 @@ We also want to have a look into tour testing as an extension to our current exp
 Ideas we want to implement in the future, but did not have enough time to implement or work out completely.
 
 - add security measures when updating decks (e.g. signatures, see [#16](https://github.com/fancy-flashcard/ffc/pull/16))
+- automatically update all third party decks (that have been installed) when starting the app &rarr; should be either a background task or triggered manually and only show a snackbar when finishing ("Updated third party decks to newest versions")
+  - this may need us to include the version number inside the [third-party-decks.json](../third-party-decks.json)
+  - this would also enable us to control the flow of updates &rarr; security feature? only allow officially tagged "releases" as urls?
 - extend format and displaying in app to show not only simple text
   - Markdown support
   - formulas similar to LaTeX

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": "Niko Lockenvitz & Rene-Pascal Fischer",
   "license": "MIT",
   "private": true,

--- a/src/helpers/addDecksHelper.ts
+++ b/src/helpers/addDecksHelper.ts
@@ -87,9 +87,14 @@ export function addDecksFromJSON(
       addedDecksAndCards.push({ name, numberOfCards: cards.length });
     }
 
+    const version = fileContent.meta.version
+      ? fileContent.meta.version
+      : undefined;
+
     showAddedDecksConfirmation(
       context,
       addedDecksAndCards,
+      version,
       updatedInsteadOfAddedFile
     );
   } catch (e) {
@@ -182,6 +187,7 @@ function updateDeckIfItExistsAndReturnStatusAndNumberOfCards(
 function showAddedDecksConfirmation(
   context: Context,
   addedDeckAndCards: addedDeckAndCards[],
+  version: string,
   updatedInsteadOfAddedFile: boolean
 ) {
   const numberOfAddedCards = addedDeckAndCards.reduce(
@@ -196,8 +202,12 @@ function showAddedDecksConfirmation(
     persistent: false,
     title: "Successfully Imported Decks",
     message: updatedInsteadOfAddedFile
-      ? "Following decks have been updated (you can see the number of cards added, updated and deleted in parentheses):"
-      : "Following decks have been added:",
+      ? "Following decks have been updated" +
+        (version ? " to version " + version : "") +
+        " (number of cards added / updated / deleted):"
+      : "The following decks" +
+        (version ? " (version: " + version + ") " : "") +
+        "have been added:",
     tableHead: { name: "Deck", value: "Number of Cards" },
     table: addedDeckAndCards.map((deck) => {
       return {

--- a/src/helpers/addDecksHelper.ts
+++ b/src/helpers/addDecksHelper.ts
@@ -87,9 +87,7 @@ export function addDecksFromJSON(
       addedDecksAndCards.push({ name, numberOfCards: cards.length });
     }
 
-    const version = fileContent.meta.version
-      ? fileContent.meta.version
-      : undefined;
+    const version = fileContent?.meta?.version;
 
     showAddedDecksConfirmation(
       context,

--- a/src/helpers/selectedDeckDialogHelper.ts
+++ b/src/helpers/selectedDeckDialogHelper.ts
@@ -56,6 +56,10 @@ export function showInfoForSelectedDeck(context: any) {
           key: "author",
           name: "Author",
         },
+        {
+          key: "version",
+          name: "Version",
+        },
       ],
     },
     {


### PR DESCRIPTION
I added version numbers to decks, because it think it makes it way easier to know when you have to update your deck.
I also added some ideas for our backlog &rarr; it's about the version numbers of third party decks and ideas to update them